### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Hypothesis for Java feasibility prototype
 =========================================
 
-`Hypothesis  <http://hypothesis.readthedocs.org/en/latest/>`_ is a modern property based testing system designed for
+`Hypothesis  <https://hypothesis.readthedocs.io/en/latest/>`_ is a modern property based testing system designed for
 mainstream languages. The original version is for Python, where it works extremely well.
 
 This is a very rough prototype of what Hypothesis could look like in Java. It's not even close to being production


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.